### PR TITLE
Link CIs to main repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # torchstain
 
 [![License](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
-[![tests](https://github.com/andreped/torchstain/workflows/tests/badge.svg)](https://github.com/andreped/torchstain/actions)
+[![tests](https://github.com/EIDOSLAB/torchstain/workflows/tests/badge.svg)](https://github.com/EIDOSLAB/torchstain/actions)
 [![Pip Downloads](https://img.shields.io/pypi/dm/torchstain?label=pip%20downloads&logo=python)](https://pypi.org/project/torchstain/)
 
 Pytorch-compatible normalization tools for histopathological images.


### PR DESCRIPTION
When implementing the CI stuff on my fork, I had to link it to my own user, but I forgot to update the repo name in the previous PR #7. Added it now.